### PR TITLE
Add OpenAI-powered quick translation Chrome extension

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,115 @@
+const DEFAULT_SETTINGS = {
+  targetLanguage: 'English',
+  direction: 'ltr',
+  apiKey: ''
+};
+
+async function getSettings() {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(DEFAULT_SETTINGS, (items) => {
+      resolve({
+        targetLanguage: items.targetLanguage || DEFAULT_SETTINGS.targetLanguage,
+        direction: items.direction || DEFAULT_SETTINGS.direction,
+        apiKey: items.apiKey || DEFAULT_SETTINGS.apiKey
+      });
+    });
+  });
+}
+
+async function setDefaultsIfNeeded() {
+  const current = await getSettings();
+  if (!current.targetLanguage || !current.direction) {
+    chrome.storage.sync.set({
+      targetLanguage: current.targetLanguage || DEFAULT_SETTINGS.targetLanguage,
+      direction: current.direction || DEFAULT_SETTINGS.direction
+    });
+  }
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  setDefaultsIfNeeded();
+});
+
+chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
+  if (request?.type === 'GET_SETTINGS') {
+    getSettings().then((settings) => {
+      sendResponse({ success: true, settings });
+    });
+    return true;
+  }
+
+  if (request?.type === 'TRANSLATE_TEXT') {
+    (async () => {
+      try {
+        const { text } = request;
+        if (!text || !text.trim()) {
+          sendResponse({ success: false, error: 'Nothing to translate.' });
+          return;
+        }
+
+        const settings = await getSettings();
+        if (!settings.apiKey) {
+          sendResponse({ success: false, error: 'Add your OpenAI API key in the extension settings.' });
+          return;
+        }
+
+        const body = {
+          model: 'gpt-4o-mini',
+          messages: [
+            {
+              role: 'system',
+              content: 'You are a professional translation assistant. Always return only the translated text without additional commentary. Preserve tone and formatting.'
+            },
+            {
+              role: 'user',
+              content: `Translate the following text to ${settings.targetLanguage} and keep it concise.\n\n${text}`
+            }
+          ],
+          temperature: 0.2
+        };
+
+        const response = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${settings.apiKey}`
+          },
+          body: JSON.stringify(body)
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          console.error('Translation request failed:', response.status, errorText);
+          let message = 'Translation failed. Check your API key and network connection.';
+          if (response.status === 401) {
+            message = 'OpenAI rejected the request. Confirm that your API key is correct.';
+          } else if (response.status === 429) {
+            message = 'The request was rate limited by OpenAI. Try again in a moment.';
+          }
+          sendResponse({ success: false, error: message });
+          return;
+        }
+
+        const data = await response.json();
+        const translation = data?.choices?.[0]?.message?.content?.trim();
+        if (!translation) {
+          sendResponse({ success: false, error: 'No translation received. Try again.' });
+          return;
+        }
+
+        sendResponse({
+          success: true,
+          translation,
+          targetLanguage: settings.targetLanguage,
+          direction: settings.direction
+        });
+      } catch (error) {
+        console.error('Unexpected translation error:', error);
+        sendResponse({ success: false, error: 'Unexpected error. Try again.' });
+      }
+    })();
+    return true;
+  }
+
+  return false;
+});

--- a/extension/contentScript.js
+++ b/extension/contentScript.js
@@ -1,0 +1,366 @@
+const overlayState = {
+  root: null,
+  card: null,
+  translationEl: null,
+  originalEl: null,
+  statusEl: null,
+  spinnerEl: null,
+  statusTextEl: null,
+  languageLabel: null,
+  visible: false
+};
+
+const settingsState = {
+  targetLanguage: 'English',
+  direction: 'ltr'
+};
+
+const RTL_REGEX = /[\u0591-\u07FF\uFB1D-\uFDFF\uFE70-\uFEFC]/;
+let latestRequestToken = 0;
+
+function ensureOverlay() {
+  if (overlayState.root) {
+    return overlayState;
+  }
+
+  const root = document.createElement('div');
+  root.id = 'qtai-overlay-root';
+  root.style.position = 'absolute';
+  root.style.zIndex = '2147483647';
+  root.style.display = 'none';
+  root.style.pointerEvents = 'none';
+
+  const shadow = root.attachShadow({ mode: 'open' });
+  shadow.innerHTML = `
+    <style>
+      :host {
+        all: initial;
+      }
+      *, *::before, *::after {
+        box-sizing: border-box;
+        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      }
+      .card {
+        min-width: 240px;
+        max-width: 340px;
+        background: linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(247, 248, 255, 0.88));
+        border: 1px solid rgba(255, 255, 255, 0.6);
+        border-radius: 16px;
+        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.18);
+        padding: 14px 16px 16px;
+        color: #0f172a;
+        backdrop-filter: blur(18px);
+        pointer-events: auto;
+      }
+      .header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 10px;
+      }
+      .lang-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 13px;
+        font-weight: 600;
+        padding: 4px 10px;
+        background: rgba(79, 70, 229, 0.12);
+        color: #4338ca;
+        border-radius: 999px;
+      }
+      .dot {
+        display: inline-block;
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: #6366f1;
+      }
+      button.close {
+        border: none;
+        background: rgba(15, 23, 42, 0.04);
+        color: rgba(15, 23, 42, 0.6);
+        border-radius: 8px;
+        width: 28px;
+        height: 28px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 16px;
+        cursor: pointer;
+        transition: background 0.2s ease, color 0.2s ease;
+      }
+      button.close:hover {
+        background: rgba(79, 70, 229, 0.12);
+        color: #4f46e5;
+      }
+      .translation {
+        font-size: 17px;
+        line-height: 1.5;
+        font-weight: 600;
+        white-space: pre-wrap;
+        color: #111827;
+      }
+      .original {
+        margin-top: 12px;
+        padding-top: 10px;
+        border-top: 1px solid rgba(148, 163, 184, 0.3);
+        font-size: 13px;
+        line-height: 1.5;
+        color: #475569;
+        white-space: pre-wrap;
+      }
+      .status {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+        color: #6366f1;
+        margin-bottom: 12px;
+      }
+      .spinner {
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        border: 2px solid rgba(99, 102, 241, 0.2);
+        border-top-color: #4f46e5;
+        animation: spin 0.9s linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      .hidden {
+        display: none;
+      }
+    </style>
+    <div class="card" part="card">
+      <div class="header">
+        <span class="lang-chip"><span class="dot"></span><span id="language-label">Translating…</span></span>
+        <button class="close" type="button" aria-label="Close translation">✕</button>
+      </div>
+      <div class="status" id="status">
+        <span class="spinner" id="spinner" aria-hidden="true"></span>
+        <span id="status-text">Translating…</span>
+      </div>
+      <div class="translation" id="translation" dir="ltr"></div>
+      <div class="original" id="original"></div>
+    </div>
+  `;
+
+  const card = shadow.querySelector('.card');
+  const closeButton = shadow.querySelector('button.close');
+  const translationEl = shadow.getElementById('translation');
+  const originalEl = shadow.getElementById('original');
+  const statusEl = shadow.getElementById('status');
+  const spinnerEl = shadow.getElementById('spinner');
+  const statusTextEl = shadow.getElementById('status-text');
+  const languageLabel = shadow.getElementById('language-label');
+
+  closeButton.addEventListener('click', hideOverlay);
+
+  overlayState.root = root;
+  overlayState.card = card;
+  overlayState.translationEl = translationEl;
+  overlayState.originalEl = originalEl;
+  overlayState.statusEl = statusEl;
+  overlayState.spinnerEl = spinnerEl;
+  overlayState.statusTextEl = statusTextEl;
+  overlayState.languageLabel = languageLabel;
+
+  document.body.appendChild(root);
+
+  return overlayState;
+}
+
+function hideOverlay() {
+  if (!overlayState.root) {
+    return;
+  }
+  overlayState.root.style.display = 'none';
+  overlayState.visible = false;
+  latestRequestToken += 1;
+}
+
+function showOverlay(rect) {
+  const state = ensureOverlay();
+  const root = state.root;
+  root.style.display = 'block';
+  root.style.visibility = 'hidden';
+
+  const initialLeft = rect.left + window.scrollX;
+  const initialTop = rect.bottom + window.scrollY + 12;
+  root.style.left = `${initialLeft}px`;
+  root.style.top = `${initialTop}px`;
+
+  requestAnimationFrame(() => {
+    const cardRect = state.card.getBoundingClientRect();
+    const viewportLeft = window.scrollX;
+    const viewportTop = window.scrollY;
+    const maxLeft = viewportLeft + window.innerWidth - cardRect.width - 16;
+    const maxTop = viewportTop + window.innerHeight - cardRect.height - 16;
+
+    let left = initialLeft;
+    left = Math.max(viewportLeft + 16, Math.min(left, maxLeft));
+
+    let top = initialTop;
+    if (top > maxTop) {
+      top = rect.top + window.scrollY - cardRect.height - 12;
+    }
+    top = Math.max(viewportTop + 16, Math.min(top, maxTop));
+
+    root.style.left = `${left}px`;
+    root.style.top = `${top}px`;
+    root.style.visibility = 'visible';
+    overlayState.visible = true;
+  });
+}
+
+function updateStatus(text, isLoading) {
+  const state = ensureOverlay();
+  state.statusTextEl.textContent = text;
+  state.statusEl.classList.toggle('hidden', !text);
+  state.spinnerEl.classList.toggle('hidden', !isLoading);
+}
+
+function updateTranslation(translation, original, direction, languageLabel) {
+  const state = ensureOverlay();
+  state.translationEl.textContent = translation;
+  state.translationEl.setAttribute('dir', direction);
+  state.translationEl.setAttribute('lang', languageLabel || '');
+  state.translationEl.style.textAlign = direction === 'rtl' ? 'right' : 'left';
+  state.originalEl.textContent = original;
+  state.originalEl.setAttribute('dir', 'auto');
+  state.originalEl.classList.toggle('hidden', !original);
+  state.languageLabel.textContent = languageLabel || 'Translation';
+}
+
+function detectDirection(text, fallback) {
+  if (text && RTL_REGEX.test(text)) {
+    return 'rtl';
+  }
+  return fallback || 'ltr';
+}
+
+function handleSelection() {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed) {
+    return;
+  }
+
+  const text = selection.toString().trim();
+  if (!text) {
+    return;
+  }
+
+  const range = selection.getRangeAt(0);
+  const rect = range.getBoundingClientRect();
+  if (!rect || (rect.width === 0 && rect.height === 0)) {
+    return;
+  }
+
+  showOverlay(rect);
+  updateStatus('Translating…', true);
+  updateTranslation('', text, settingsState.direction, settingsState.targetLanguage);
+
+  const requestToken = ++latestRequestToken;
+
+  chrome.runtime.sendMessage(
+    {
+      type: 'TRANSLATE_TEXT',
+      text
+    },
+    (response) => {
+      if (requestToken !== latestRequestToken) {
+        return;
+      }
+      if (chrome.runtime.lastError) {
+        updateStatus('Could not reach the translation service.', false);
+        updateTranslation('', text, settingsState.direction, settingsState.targetLanguage);
+        return;
+      }
+
+      if (!response?.success) {
+        updateStatus(response?.error || 'Translation failed.', false);
+        updateTranslation('', text, settingsState.direction, settingsState.targetLanguage);
+        return;
+      }
+
+      const direction = detectDirection(response.translation, response.direction || settingsState.direction);
+      updateStatus('', false);
+      updateTranslation(response.translation, text, direction, response.targetLanguage);
+    }
+  );
+}
+
+function refreshSettings() {
+  chrome.runtime.sendMessage({ type: 'GET_SETTINGS' }, (response) => {
+    if (response?.success) {
+      settingsState.targetLanguage = response.settings.targetLanguage;
+      settingsState.direction = response.settings.direction;
+    }
+  });
+}
+
+refreshSettings();
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== 'sync') {
+    return;
+  }
+  if (changes.targetLanguage?.newValue) {
+    settingsState.targetLanguage = changes.targetLanguage.newValue;
+    if (overlayState.visible && overlayState.languageLabel) {
+      overlayState.languageLabel.textContent = settingsState.targetLanguage;
+      overlayState.translationEl?.setAttribute('lang', settingsState.targetLanguage || '');
+    }
+  }
+  if (changes.direction?.newValue) {
+    settingsState.direction = changes.direction.newValue;
+    if (overlayState.visible && overlayState.translationEl) {
+      overlayState.translationEl.setAttribute('dir', settingsState.direction);
+      overlayState.translationEl.style.textAlign = settingsState.direction === 'rtl' ? 'right' : 'left';
+    }
+  }
+});
+
+document.addEventListener('dblclick', () => {
+  handleSelection();
+});
+
+document.addEventListener(
+  'keydown',
+  (event) => {
+    if (event.key === 'Escape') {
+      hideOverlay();
+    }
+  },
+  true
+);
+
+document.addEventListener(
+  'mousedown',
+  (event) => {
+    const state = overlayState;
+    if (!state.visible || !state.card) {
+      return;
+    }
+    const path = event.composedPath();
+    if (!path.includes(state.card)) {
+      hideOverlay();
+    }
+  },
+  true
+);
+
+window.addEventListener(
+  'scroll',
+  () => {
+    if (overlayState.visible) {
+      hideOverlay();
+    }
+  },
+  true
+);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,18 @@
+{
+  "manifest_version": 3,
+  "name": "Quick Translator AI",
+  "description": "Translate highlighted text with OpenAI by double-clicking anywhere on the page.",
+  "version": "0.1.0",
+  "permissions": ["storage", "activeTab"],
+  "host_permissions": ["https://api.openai.com/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.js"]
+    }
+  ],
+  "options_page": "options.html"
+}

--- a/extension/options.css
+++ b/extension/options.css
@@ -1,0 +1,108 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #f1f5f9;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(160deg, #f9fafb 0%, #eef2ff 100%);
+  color: #0f172a;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 32px 16px;
+}
+
+.container {
+  width: min(560px, 100%);
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.1);
+  padding: 32px;
+  backdrop-filter: blur(14px);
+}
+
+.panel__header h1 {
+  margin: 0 0 4px;
+  font-size: 24px;
+}
+
+.panel__header p {
+  margin: 0 0 24px;
+  color: #475569;
+  font-size: 14px;
+}
+
+.form {
+  display: grid;
+  gap: 20px;
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+}
+
+.field__label {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+input,
+select {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  padding: 12px 14px;
+  font-size: 15px;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+  background: rgba(255, 255, 255, 0.95);
+  color: inherit;
+}
+
+input:focus,
+select:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.55);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.field__hint {
+  color: #64748b;
+  font-size: 12px;
+}
+
+.button {
+  border: none;
+  padding: 14px 18px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #4f46e5, #6366f1);
+  color: white;
+  font-weight: 600;
+  font-size: 15px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 12px 25px rgba(79, 70, 229, 0.25);
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(79, 70, 229, 0.3);
+}
+
+.status {
+  min-height: 18px;
+  font-size: 13px;
+  color: #16a34a;
+}
+
+@media (max-width: 520px) {
+  .panel {
+    padding: 24px;
+  }
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quick Translator AI · Settings</title>
+    <link rel="stylesheet" href="options.css" />
+  </head>
+  <body>
+    <main class="container" role="main">
+      <section class="panel">
+        <header class="panel__header">
+          <h1>Quick Translator AI</h1>
+          <p>Connect your OpenAI account and choose how translations should appear.</p>
+        </header>
+        <form id="settings-form" class="form" autocomplete="off">
+          <label class="field">
+            <span class="field__label">OpenAI API key</span>
+            <input type="password" id="apiKey" name="apiKey" placeholder="sk-..." aria-describedby="apiHint" />
+            <small id="apiHint" class="field__hint">Your key is stored securely in your browser and never shared.</small>
+          </label>
+
+          <label class="field">
+            <span class="field__label">Target language</span>
+            <input type="text" id="targetLanguage" name="targetLanguage" placeholder="e.g. English" required />
+          </label>
+
+          <label class="field">
+            <span class="field__label">Reading direction</span>
+            <select id="direction" name="direction">
+              <option value="ltr">Left to right</option>
+              <option value="rtl">Right to left</option>
+            </select>
+          </label>
+
+          <button type="submit" class="button">Save settings</button>
+          <p class="status" id="status" role="status" aria-live="polite"></p>
+        </form>
+      </section>
+    </main>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,0 +1,51 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('settings-form');
+  const apiKeyInput = document.getElementById('apiKey');
+  const targetLanguageInput = document.getElementById('targetLanguage');
+  const directionSelect = document.getElementById('direction');
+  const status = document.getElementById('status');
+
+  chrome.storage.sync.get(
+    {
+      apiKey: '',
+      targetLanguage: 'English',
+      direction: 'ltr'
+    },
+    (items) => {
+      apiKeyInput.value = items.apiKey || '';
+      targetLanguageInput.value = items.targetLanguage || 'English';
+      directionSelect.value = items.direction || 'ltr';
+    }
+  );
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const apiKey = apiKeyInput.value.trim();
+    const targetLanguage = targetLanguageInput.value.trim() || 'English';
+    const direction = directionSelect.value;
+
+    chrome.storage.sync.set(
+      {
+        apiKey,
+        targetLanguage,
+        direction
+      },
+      () => {
+        status.textContent = 'Settings saved.';
+        status.style.color = '#16a34a';
+        setTimeout(() => {
+          status.textContent = '';
+        }, 2500);
+      }
+    );
+  });
+
+  targetLanguageInput.addEventListener('change', () => {
+    const value = targetLanguageInput.value.trim().toLowerCase();
+    const rtlLanguages = ['arabic', 'hebrew', 'farsi', 'persian', 'urdu'];
+    if (rtlLanguages.includes(value)) {
+      directionSelect.value = 'rtl';
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a manifest, background worker, and content script that connect highlighted text to OpenAI for translations
- implement a polished translation overlay with double-click activation, right-to-left handling, and graceful positioning
- provide an options page for configuring the API key, target language, and reading direction

## Testing
- not run (manual browser testing required)


------
https://chatgpt.com/codex/tasks/task_e_68d0394bca38832f8cbfa1c786f9bcb8